### PR TITLE
replace np.bool by bool

### DIFF
--- a/c3d/header.py
+++ b/c3d/header.py
@@ -81,7 +81,7 @@ class Header(object):
 
         self.event_block = b''
         self.event_timings = np.zeros(0, dtype=np.float32)
-        self.event_disp_flags = np.zeros(0, dtype=np.bool)
+        self.event_disp_flags = np.zeros(0, dtype=bool)
         self.event_labels = []
 
         if handle:
@@ -222,7 +222,7 @@ class Header(object):
 
         read_count = self.event_count
         self.event_timings = np.zeros(read_count, dtype=np.float32)
-        self.event_disp_flags = np.zeros(read_count, dtype=np.bool)
+        self.event_disp_flags = np.zeros(read_count, dtype=bool)
         self.event_labels = np.empty(read_count, dtype=object)
         for i in range(read_count):
             ilong = i * 4
@@ -285,7 +285,7 @@ class Header(object):
         self.event_count = write_count
         # Update event block
         self.event_timings = event_timings[:write_count]
-        self.event_disp_flags = np.ones(write_count, dtype=np.bool)
+        self.event_disp_flags = np.ones(write_count, dtype=bool)
         self.event_labels = event_labels[:write_count]
         self.event_block = struct.pack(fmt,
                                        event_timings.tobytes(),

--- a/c3d_importer.py
+++ b/c3d_importer.py
@@ -95,7 +95,7 @@ def load(operator, context, filepath="",
         if apply_label_mask:
             point_mask = parser.generate_label_mask(labels, 'POINT')
         else:
-            point_mask = np.ones(np.shape(labels), np.bool)
+            point_mask = np.ones(np.shape(labels), bool)
         labels = C3DParseDictionary.make_labels_unique(labels[point_mask])
         # Equivalent to the number of channels used in POINT data.
         nlabels = len(labels)
@@ -182,7 +182,7 @@ def read_data(parser, blen_curves, labels, point_mask, global_orient,
 
     # Generate numpy arrays to store POINT data from each frame before creating keyframes.
     point_frames = np.zeros([nframes, 3, nlabels], dtype=np.float32)
-    valid_samples = np.empty([nframes, nlabels], dtype=np.bool)
+    valid_samples = np.empty([nframes, nlabels], dtype=bool)
 
     ##
     # Start reading POINT blocks (and analog, but analog signals from force plates etc. are not supported).

--- a/c3d_parse_dictionary.py
+++ b/c3d_parse_dictionary.py
@@ -366,7 +366,7 @@ class C3DParseDictionary:
         soft_dict = self.software_dictionary()
         if soft_dict is not None:
             return self.generate_software_label_mask(soft_dict, labels, group)
-        return np.ones(np.shape(labels), dtype=np.bool)
+        return np.ones(np.shape(labels), dtype=bool)
 
     def generate_software_label_mask(self, soft_dict, labels, group='POINT'):
         ''' Generate a label mask in regard to the software used to generate the file.
@@ -379,7 +379,7 @@ class C3DParseDictionary:
             group:      Group labels are associated with, should be 'POINT' or 'ANALOG'.
             Return:     Mask defined using a numpy bool array of equal shape to label argument.
         '''
-        mask = np.ones(np.shape(labels), dtype=np.bool)
+        mask = np.ones(np.shape(labels), dtype=bool)
         equal, contain, param = soft_dict['%s_EXCLUDE' % group]
 
         def contains_seq(item, words):


### PR DESCRIPTION
np.bool is deprecated since numpy 1.20. Bool will work with any version of Blender, numpy, and Python.

It is not done yet, but I would like to add the possibility to import c3d files to my addon Sim2Blend: https://github.com/davidpagnon/Sim2Blend
Thanks for saving me all that work!